### PR TITLE
投稿操作の制限

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!, only: [:update, :create, :edit, :destroy]
   def index
     @posts =Post.all
   end


### PR DESCRIPTION
# What
ユーザーがロウインしている場合に投稿、削除、編集できる実装

# Why
ログインしていないユーザーが投稿内容を不用意に変更を加えないようにするため